### PR TITLE
Fixes #1

### DIFF
--- a/src/DotNetMicroserviceTemplates.csproj
+++ b/src/DotNetMicroserviceTemplates.csproj
@@ -2,7 +2,7 @@
     
     <PropertyGroup>
         <PackageType>Template</PackageType>
-        <PackageVersion>1.0.11-alpha</PackageVersion>
+        <PackageVersion>1.0.12-alpha</PackageVersion>
         <PackageId>Kishotta.Utility.Microservice.Templates</PackageId>
         <Title>Kishotta Microservice Templates</Title>
         <Authors>Connor Eaves</Authors>

--- a/src/Templates/Microservice/.template.config/template.json
+++ b/src/Templates/Microservice/.template.config/template.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/template",
+  "$schema": "https://json.schemastore.org/template",
   "identity": "Microservice.Template",
   "author": "Connor Eaves",
   "classifications": [ "C#", "Asp.Net Core", "Core", "Microservice", "MVC" ],
@@ -18,17 +18,17 @@
             "text": "Add generated projects to solution manually."
             }
         ],
-      "continueOnError": true,
+      "continueOnError": true
     }
   ],
   "sourceName": "Microservice",
   "preferNameDirectory": true,
   "primaryOutputs": [
     {
-      "path": "Microservice.Api.csproj"
+      "path": "Microservice.Api\\Microservice.Api.csproj"
     },
     {
-      "path": "Microservice.Presentation.csproj"
+      "path": "Microservice.Presentation\\Microservice.Presentation.csproj"
     }
   ]
 }


### PR DESCRIPTION
It took some trial and error, but I found the correct string format for the `primaryOutputs` array in the Microservice template config to automagically add the projects to an existing solution.

The output looks a bit strange (note the use of both `\` and `/` in the `*.csproj` paths), but it does work;

```
➜ MicroserviceTest\src\Services> dotnet new microservice --name ExampleService
The template "Microservice Template" was created successfully.

Processing post-creation actions...
Adding project reference(s) to solution file. Running dotnet sln D:\MicroserviceTest\src\MicroserviceTest.sln add ExampleService\ExampleService.Api/ExampleService.Api.csproj ExampleService\ExampleService.Presentation/ExampleService.
Presentation.csproj
Successfully added
    project(s): ExampleService\ExampleService.Api/ExampleService.Api.csproj ExampleService\ExampleService.Presentation/ExampleService.Presentation.csproj
    to solution file: D:\MicroserviceTest\src\MicroserviceTest.sln
    solution folder:
```

